### PR TITLE
Add more time zones and alphabetical list

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Simple Time Zone Clock",
     "version": "1.0",
-    "description": "Displays the current time in Local, UTC, JST, and NYC time zones.",
+    "description": "Displays the current time in Local, UTC and a variety of global time zones.",
     "icons": {
       "16": "icons/icon16.png",
       "48": "icons/icon48.png",

--- a/popup.css
+++ b/popup.css
@@ -93,4 +93,28 @@ div:last-child {
     color: #009739; /* Green */
 }
 
+#berlinTime { /* Berlin */
+    color: #1E90FF; /* Dodger Blue */
+}
+
+#buenosAiresTime { /* Buenos Aires */
+    color: #2E8B57; /* Sea Green */
+}
+
+#johannesburgTime { /* Johannesburg */
+    color: #556B2F; /* Dark Olive Green */
+}
+
+#parisTime { /* Paris */
+    color: #C71585; /* Medium Violet Red */
+}
+
+#singaporeTime { /* Singapore */
+    color: #DC143C; /* Crimson */
+}
+
+#vancouverTime { /* Vancouver */
+    color: #4682B4; /* Steel Blue */
+}
+
 /* --- End of New Color Styles --- */

--- a/popup.html
+++ b/popup.html
@@ -10,18 +10,24 @@
     <h1>Current Time</h1>
     <div id="localTime">Loading...</div>
     <div id="utcTime">Loading...</div>
-    <div id="jstTime">Loading...</div>
-    <div id="nycTime">Loading...</div>
+    <div id="beijingTime">Loading...</div>
+    <div id="berlinTime">Loading...</div>
+    <div id="buenosAiresTime">Loading...</div>
+    <div id="cairoTime">Loading...</div>
+    <div id="johannesburgTime">Loading...</div>
     <div id="londonTime">Loading...</div>
+    <div id="mexicoCityTime">Loading...</div>
     <div id="milanTime">Loading...</div>
     <div id="moscowTime">Loading...</div>
-    <div id="tehranTime">Loading...</div>
-    <div id="delhiTime">Loading...</div> 
-    <div id="beijingTime">Loading...</div>
-    <div id="sydneyTime">Loading...</div>
-    <div id="mexicoCityTime">Loading...</div>
-    <div id="cairoTime">Loading...</div>  
+    <div id="delhiTime">Loading...</div>
+    <div id="nycTime">Loading...</div>
+    <div id="parisTime">Loading...</div>
     <div id="saoPauloTime">Loading...</div>
+    <div id="singaporeTime">Loading...</div>
+    <div id="sydneyTime">Loading...</div>
+    <div id="tehranTime">Loading...</div>
+    <div id="jstTime">Loading...</div>
+    <div id="vancouverTime">Loading...</div>
 
 
     <script src="popup.js"></script>

--- a/popup.js
+++ b/popup.js
@@ -32,18 +32,24 @@ function updateTimes() {
 
     //--- Other Time Zones ---
     setTime('utcTime', 'UTC', 'UTC');
-    setTime('jstTime', 'Asia/Tokyo', 'Tokyo (JST)');
-    setTime('nycTime', 'America/New_York', 'New York (ET)');
+    setTime('beijingTime', 'Asia/Shanghai', 'Beijing (CST)');
+    setTime('berlinTime', 'Europe/Berlin', 'Berlin (CET)');
+    setTime('buenosAiresTime', 'America/Argentina/Buenos_Aires', 'Buenos Aires (ART)');
+    setTime('cairoTime', 'Africa/Cairo', 'Cairo (EET)');
+    setTime('johannesburgTime', 'Africa/Johannesburg', 'Johannesburg (SAST)');
     setTime('londonTime', 'Europe/London', 'London (UK)');
+    setTime('mexicoCityTime', 'America/Mexico_City', 'Mexico City (CST)');
     setTime('milanTime', 'Europe/Rome', 'Milan (CET)'); //Italy uses Rome's zone
     setTime('moscowTime', 'Europe/Moscow', 'Moscow (MSK)');
-    setTime('tehranTime', 'Asia/Tehran', 'Tehran (IRST)');
     setTime('delhiTime', 'Asia/Kolkata', 'New Delhi (IST)'); //India uses Kolkata's zone
-    setTime('beijingTime', 'Asia/Shanghai', 'Beijing (CST)'); //China uses Shanghai's zone base
-    setTime('sydneyTime', 'Australia/Sydney', 'Sydney (AEST)');
-    setTime('mexicoCityTime', 'America/Mexico_City', 'Mexico City (CST)');
-    setTime('cairoTime', 'Africa/Cairo', 'Cairo (EET)');
+    setTime('nycTime', 'America/New_York', 'New York (ET)');
+    setTime('parisTime', 'Europe/Paris', 'Paris (CET)');
     setTime('saoPauloTime', 'America/Sao_Paulo', 'São Paulo (BRT)'); //Major Brazil Hub Time
+    setTime('singaporeTime', 'Asia/Singapore', 'Singapore (SGT)');
+    setTime('sydneyTime', 'Australia/Sydney', 'Sydney (AEST)');
+    setTime('tehranTime', 'Asia/Tehran', 'Tehran (IRST)');
+    setTime('jstTime', 'Asia/Tokyo', 'Tokyo (JST)');
+    setTime('vancouverTime', 'America/Vancouver', 'Vancouver (PT)');
 
 }
 


### PR DESCRIPTION
## Summary
- improve manifest description
- sort time zones alphabetically in the popup
- add Berlin, Buenos Aires, Johannesburg, Paris, Singapore and Vancouver
- adjust popup.js and popup.css for the new locations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843421f4124832db1248f08e124d2dc