### PR TITLE
Add futuristic design and more time zones

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -1,31 +1,35 @@
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap');
+
 /* --- Existing Base Styles --- */
 body {
-    font-family: sans-serif;
+    font-family: 'Orbitron', sans-serif;
     min-width: 250px; /* Adjust as needed */
     padding: 10px;
     font-size: 14px;
-    background-color: #f9f9f9; /* Light background */
-    color: #333; /* Default text color */
+    background: linear-gradient(135deg, #0f2027, #203a43, #2c5364);
+    color: #f0f0f0;
 }
 
 h1 {
     font-size: 16px;
     margin-top: 0;
     margin-bottom: 12px;
-    color: #1a73e8; /* Google Blue */
+    color: #00ffff;
     text-align: center;
+    text-shadow: 0 0 5px #00ffff;
 }
 
 div {
     padding: 5px 0;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid #444;
     white-space: nowrap; /* Prevent wrapping */
+    text-shadow: 0 0 3px rgba(255,255,255,0.6);
 }
 
 hr { /* Style for the optional separator */
     border: 0;
     height: 1px;
-    background-color: #ddd;
+    background-color: #555;
     margin: 5px 0;
 }
 
@@ -115,6 +119,22 @@ div:last-child {
 
 #vancouverTime { /* Vancouver */
     color: #4682B4; /* Steel Blue */
+}
+
+#istanbulTime { /* Istanbul */
+    color: #FF4500; /* OrangeRed */
+}
+
+#dhakaTime { /* Dhaka */
+    color: #FFD700; /* Gold */
+}
+
+#dubaiTime { /* Dubai */
+    color: #40E0D0; /* Turquoise */
+}
+
+#seoulTime { /* Seoul */
+    color: #7FFF00; /* Chartreuse */
 }
 
 /* --- End of New Color Styles --- */

--- a/popup.html
+++ b/popup.html
@@ -28,6 +28,10 @@
     <div id="tehranTime">Loading...</div>
     <div id="jstTime">Loading...</div>
     <div id="vancouverTime">Loading...</div>
+    <div id="istanbulTime">Loading...</div>
+    <div id="dhakaTime">Loading...</div>
+    <div id="dubaiTime">Loading...</div>
+    <div id="seoulTime">Loading...</div>
 
 
     <script src="popup.js"></script>

--- a/popup.js
+++ b/popup.js
@@ -50,6 +50,10 @@ function updateTimes() {
     setTime('tehranTime', 'Asia/Tehran', 'Tehran (IRST)');
     setTime('jstTime', 'Asia/Tokyo', 'Tokyo (JST)');
     setTime('vancouverTime', 'America/Vancouver', 'Vancouver (PT)');
+    setTime('istanbulTime', 'Europe/Istanbul', 'Istanbul (TRT)');
+    setTime('dhakaTime', 'Asia/Dhaka', 'Dhaka (BST)');
+    setTime('dubaiTime', 'Asia/Dubai', 'Dubai (GST)');
+    setTime('seoulTime', 'Asia/Seoul', 'Seoul (KST)');
 
 }
 


### PR DESCRIPTION
## Summary
- overhaul popup CSS with neon dark theme
- show times for Istanbul, Dhaka, Dubai and Seoul
- import Orbitron font for a sci‑fi look

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684343a08dec832db116a4d000aaf1a9