### PR TITLE
Update fonts and colors

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -1,12 +1,12 @@
-@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
 
 /* --- Simplified, readable styles --- */
 body {
-    font-family: 'Orbitron', sans-serif;
+    font-family: 'Roboto', sans-serif;
     min-width: 250px;
     padding: 10px;
     font-size: 14px;
-    background: #ffffff;
+    background: #f8f9fa;
     color: #333333;
 }
 
@@ -14,7 +14,7 @@ h1 {
     font-size: 16px;
     margin-top: 0;
     margin-bottom: 12px;
-    color: #333333;
+    color: #0066cc;
     text-align: center;
 }
 
@@ -22,6 +22,7 @@ div {
     padding: 5px 0;
     border-bottom: 1px solid #dddddd;
     white-space: nowrap;
+    color: #444444;
 }
 
 div:last-child {

--- a/privacy.html
+++ b/privacy.html
@@ -4,9 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy - timezones-extension</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     <style>
         body {
-            font-family: sans-serif;
+            font-family: 'Roboto', sans-serif;
             line-height: 1.6;
             padding: 20px;
             max-width: 600px;


### PR DESCRIPTION
## Summary
- use Roboto font for popup and privacy page
- apply a soft background colour and accent heading
- give popup text a slightly darker shade

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843463bbd54832d94c7ede5709991b7